### PR TITLE
quotations fixed onboarding in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,16 +2,16 @@
 # Tovy
 ############
 
-SESSION_SECRET=your-super-secret-32-char-key # Generate one here --> https://bitwarden.com/password-generator/
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DATABASE # Leave this blank if you are self hosting with Docker Compose
+SESSION_SECRET="your-super-secret-32-char-key" # Generate one here --> https://bitwarden.com/password-generator/
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DATABASE" # Leave this blank if you are self hosting with Docker Compose
 
 ############
 # Database - Only required if you are using postgres with Docker Compose
 # *Change password in production*
 ############
 
-POSTGRES_PASSWORD=supersecretpassword
-POSTGRES_USER=postgres
-POSTGRES_DB=tovy
-POSTGRES_PORT=5432
+POSTGRES_PASSWORD="supersecretpassword"
+POSTGRES_USER="postgres"
+POSTGRES_DB="tovy"
+POSTGRES_PORT="5432"
 


### PR DESCRIPTION
I figured out that the reason why onboarding wasn't working was because the .env lacked quotation marks around the environment variables. This fixed onboarding and everything now works.